### PR TITLE
Binary data reading is invalid

### DIFF
--- a/src/PureWebsockets/PureWebSocket.cs
+++ b/src/PureWebsockets/PureWebSocket.cs
@@ -371,16 +371,20 @@ namespace PureWebSockets
                         }
                         else
                         {
+
+                            var exactDataBuffer = new byte[res.Count];
+                            Array.Copy(buffer, 0, exactDataBuffer, 0, res.Count);
                             // handle binary data
                             if (!res.EndOfMessage)
                             {
-                                binary.AddRange(buffer.Where(b => b != '\0'));
+                                binary.AddRange(exactDataBuffer);
                                 goto READ;
                             }
 
-                            binary.AddRange(buffer.Where(b => b != '\0'));
-                            Log($"Binary fully received: {Encoding.UTF8.GetString(binary.ToArray())}");
-                            Task.Run(() => OnData?.Invoke(binary.ToArray())).Wait(50);
+                            binary.AddRange(exactDataBuffer);
+                            var binaryData = binary.ToArray();
+                            LogData("Binary fully received", binaryData);
+                            Task.Run(() => OnData?.Invoke(binaryData)).Wait(50);
                         }
 
                         // ReSharper disable once RedundantAssignment
@@ -518,6 +522,11 @@ namespace PureWebSockets
         {
             if (_options.DebugMode)
                 Task.Run(() => Console.WriteLine($"{DateTime.Now:O} PureWebSocket.{memberName}: {message}"));
+        }
+        internal void LogData(string message, byte[] data, [CallerMemberName] string memberName = "")
+        {
+            if (_options.DebugMode)
+                Task.Run(() => Console.WriteLine($"{DateTime.Now:O} PureWebSocket.{memberName}: {message}, data: {BitConverter.ToString(data)}"));
         }
     }
 }

--- a/src/PureWebsockets/PureWebSocket.cs
+++ b/src/PureWebsockets/PureWebSocket.cs
@@ -371,7 +371,6 @@ namespace PureWebSockets
                         }
                         else
                         {
-
                             var exactDataBuffer = new byte[res.Count];
                             Array.Copy(buffer, 0, exactDataBuffer, 0, res.Count);
                             // handle binary data


### PR DESCRIPTION
Reading binary data has delivered me a lot of strange data. So a looked in the code and saw the following:
`if (!res.EndOfMessage)
{
     binary.AddRange(buffer.Where(b => b != '\0'));
     goto READ;
}

binary.AddRange(buffer.Where(b => b != '\0'));`

Binary data can contain also contain a lot of zeros. Ignoring here that goto is also very evil 🙈 

I have fixed it with copying the amount of data you got from the websocket to a new buffer and than add it to the byte list.

I also added a new log method. Just for performance reasons. I don't like it to generate a string of n byte data just that the log method returns anyway because logging is disabled. 

Cheers,
Patrik