### PR TITLE
Expose ClientWebSocket

### DIFF
--- a/src/PureWebSockets/PureWebSocket.cs
+++ b/src/PureWebSockets/PureWebSocket.cs
@@ -34,6 +34,11 @@ namespace PureWebSockets
         private Task _monitorTask;
         private Task _listenerTask;
         private Task _senderTask;
+        
+        /// <summary>
+        /// The Client Web Socket Instance
+        /// </summary>
+        public ClientWebSocket Ws { get => _ws; }        
 
         /// <summary>
         /// The current state of the connection.


### PR DESCRIPTION
To be able to access the extended properties / methods of .NET CORE

Example:

(Ignore SSL working .NET CORE)

`
var proxy = WebRequest.DefaultWebProxy;
proxy.Credentials = CredentialCache.DefaultNetworkCredentials;

var cwOptions = new PureWebSocketOptions()
{
    Proxy = proxy
};

_cws2 = new PureWebSocket("wss://example:5050/replicante", cwOptions);
_cws2.Ws.Options.RemoteCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
`