### PR TITLE
24 - Use byte[] instead of string so we can pass raw bytes if needed.…

### DIFF
--- a/src/PureWebSockets/Delegates.cs
+++ b/src/PureWebSockets/Delegates.cs
@@ -15,7 +15,7 @@ namespace PureWebSockets
 
     public delegate void Error(object sender, Exception ex);
 
-    public delegate void SendFailed(object sender, string data, Exception ex);
+    public delegate void SendFailed(object sender, byte[] data, Exception ex);
 
     public delegate void Fatality(object sender, string reason);
 }

--- a/src/PureWebSockets/RequestMessage.cs
+++ b/src/PureWebSockets/RequestMessage.cs
@@ -1,0 +1,14 @@
+namespace PureWebSockets
+{
+    public class RequestMessage
+    {
+        public MessageType Type { get; set; }
+        public byte[] Data { get; set; }
+    }
+
+    public enum MessageType
+    {
+        BINARY,
+        TEXT
+    }
+}

--- a/src/PureWebsocketsTest/Program.cs
+++ b/src/PureWebsocketsTest/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.WebSockets;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using PureWebSockets;
@@ -39,7 +40,7 @@ namespace PureWebsocketsTest
             goto RESTART;
         }
 
-        private static void Ws_OnSendFailed(object sender, string data, Exception ex)
+        private static void Ws_OnSendFailed(object sender, byte[] data, Exception ex)
         {
             OutputConsole.WriteLine($"{DateTime.Now} {((PureWebSocket)sender).InstanceName} Send Failed: {ex.Message}\r\n", ConsoleColor.Red);
         }
@@ -79,7 +80,7 @@ namespace PureWebsocketsTest
             }
             else
             {
-                Ws_OnSendFailed(_ws, "", new Exception("Send Returned False"));
+                Ws_OnSendFailed(_ws, Encoding.UTF8.GetBytes(string.Empty), new Exception("Send Returned False"));
             }
         }
     }


### PR DESCRIPTION
… This has some breaking changes unfortunately (OnSendFailed event)

Fixed #24 